### PR TITLE
fix: wrong message for unclosed quoted pattern

### DIFF
--- a/lsp/src/document.rs
+++ b/lsp/src/document.rs
@@ -31,7 +31,7 @@ impl Document {
   pub fn new(uri: Uri, version: i32, text: Box<str>) -> Document {
     let parsed = Yoke::attach_to_cart(text, |text| {
       let (ast, mut diagnostics, info) = mf2_parser::parse(text);
-      let scope = mf2_parser::analyse_semantics(&ast, &mut diagnostics);
+      let scope = mf2_parser::analyze_semantics(&ast, &mut diagnostics);
 
       ParsedDocument {
         ast,

--- a/parser/src/diagnostic.rs
+++ b/parser/src/diagnostic.rs
@@ -235,7 +235,7 @@ diagnostics! {
       fatal: false,
     },
     UnterminatedQuotedPattern { span: Span } => {
-      message: ("Quoted pattern is missing the closing braces ('}}')."),
+      message: ("Quoted pattern is missing the closing braces ('}}}}')."),
       span: *span,
       fatal: true,
     },

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -49,11 +49,11 @@ pub fn parse(message: &str) -> (Message, Vec<Diagnostic>, SourceTextInfo) {
   Parser::new(message).parse()
 }
 
-pub fn analyse_semantics<'text>(
+pub fn analyze_semantics<'text>(
   message: &Message<'text>,
   diagnostics: &mut Vec<Diagnostic<'text>>,
 ) -> Scope<'text> {
-  Scope::analyse(message, diagnostics)
+  Scope::analyze(message, diagnostics)
 }
 
 /// Check if a string is a syntactically valid name in MF2.

--- a/parser/src/scope.rs
+++ b/parser/src/scope.rs
@@ -18,7 +18,7 @@ pub struct Scope<'text> {
 }
 
 impl Scope<'_> {
-  pub(crate) fn analyse<'text>(
+  pub(crate) fn analyze<'text>(
     ast: &ast::Message<'text>,
     diagnostics: &mut Vec<Diagnostic<'text>>,
   ) -> Scope<'text> {
@@ -29,7 +29,6 @@ impl Scope<'_> {
       diagnostics,
     };
     visitor.visit_message(ast);
-
     visitor.scope
   }
 

--- a/test/fixtures/complex/quoted/missing_close.mf2
+++ b/test/fixtures/complex/quoted/missing_close.mf2
@@ -6,7 +6,7 @@ QuotedPattern       ^^^^^^^^^^^^^^^ 0:0-0:15
 Pattern               ^^^^^^^^^^^^^ 0:2-0:15
 Text                  ^^^^^^^^^^^^^ 0:2-0:15
 === diagnostics ===
-Quoted pattern is missing the closing braces ('}'). (at @0..15)
+Quoted pattern is missing the closing braces ('}}'). (at @0..15)
   {{Hello, World!
   ^^^^^^^^^^^^^^^
 === formatted ===

--- a/test/fixtures/complex/quoted/missing_second_quote.mf2
+++ b/test/fixtures/complex/quoted/missing_second_quote.mf2
@@ -9,7 +9,7 @@ Text                  ^^^^^^^^^^^^^^ 0:2-0:16
 The closing brace character ('}') is invalid inside of messages, and must be escaped as '\}'. (at @15..16)
   {{Hello, World!}
                  ^
-Quoted pattern is missing the closing braces ('}'). (at @0..16)
+Quoted pattern is missing the closing braces ('}}'). (at @0..16)
   {{Hello, World!}
   ^^^^^^^^^^^^^^^^
 === formatted ===


### PR DESCRIPTION
Also americanizes the spelling of `analyze`.