### PR TITLE
Add declaration snippets at the root of complex messages

### DIFF
--- a/lsp/src/completions.rs
+++ b/lsp/src/completions.rs
@@ -198,25 +198,15 @@ fn get_completion_type<'text>(
   use ast::*;
   use AnyNode as X;
 
-  let get_invalid_statement_span = || {
-    diagnostics.iter().find_map(|diagnostic| match diagnostic {
-      Diagnostic::InvalidStatement { span, .. }
-        if span.start < loc && loc <= span.end =>
-      {
-        Some(*span)
-      }
-      _ => None,
-    })
-  };
-
-  // An empty (or whitespace-only) message is parsed as a simple message with a
-  // single empty text part. Offer declaration snippets at its root.
+  // An empty (or whitespace-only) message.
+  //
+  // |
   if let Message::Simple(pattern) = ast {
     if let [PatternPart::Text(text)] = &pattern.parts[..] {
       if text.content.trim().is_empty() {
         return AllowedCompletionType::Declaration {
           allow_match: true,
-          replace: get_invalid_statement_span(),
+          replace: None,
         };
       }
     }
@@ -228,13 +218,15 @@ fn get_completion_type<'text>(
   };
 
   // The cursor can be in whitespace just outside the complex message's span
-  // (e.g. on a fresh line after the last declaration). As long as there is no
-  // body yet, that is still a valid spot for another declaration.
+  // (e.g. on a fresh line after the last declaration).
+  //
+  // .local $x = {1}
+  // |
   if let (X::Message(_), Message::Complex(message)) = (&current_node, ast) {
     if !has_body(message) {
       return AllowedCompletionType::Declaration {
         allow_match: true,
-        replace: get_invalid_statement_span(),
+        replace: None,
       };
     }
   }
@@ -242,9 +234,26 @@ fn get_completion_type<'text>(
   match (current_node, parent_node, previous_node) {
     (X::ComplexMessage(message), _, _) => {
       // At the root of a complex message, in between declarations or before the
-      // body: `.local ...` <here> `{{...}}`.
+      // body:
+      //
+      // .local $x = {1}| {{hi}}
+      //
+      // .local $x = {1}  .lo|c  {{hi  }}
+      //
+      // A partially-typed keyword (e.g. `.lo`) shows up as an invalid statement
+      // spanning the cursor; the snippet replaces it.
+      let replace =
+        diagnostics.iter().find_map(|diagnostic| match diagnostic {
+          Diagnostic::InvalidStatement { span, keyword }
+            if span.start < loc && loc <= span.end =>
+          {
+            let keyword_end = span.start + '.' + *keyword;
+            Some(Span::new(span.start..keyword_end.max(loc)))
+          }
+          _ => None,
+        });
       AllowedCompletionType::Declaration {
-        replace: get_invalid_statement_span(),
+        replace,
         allow_match: !has_body(message),
       }
     }

--- a/lsp/src/completions.rs
+++ b/lsp/src/completions.rs
@@ -1,6 +1,7 @@
 use mf2_parser::ast;
 use mf2_parser::ast::AnyNode;
 use mf2_parser::ast::Message;
+use mf2_parser::Diagnostic;
 use mf2_parser::Location;
 use mf2_parser::Scope;
 use mf2_parser::Span;
@@ -15,15 +16,40 @@ pub enum CompletionAction {
 }
 
 #[derive(Debug)]
+pub enum CompletionKind {
+  Variable,
+  Snippet,
+}
+
+#[derive(Debug)]
 pub struct Completion {
+  /// The text shown in the completion list.
+  pub label: String,
+  /// The text inserted when the completion is accepted. For
+  /// [CompletionKind::Snippet] completions this is an LSP snippet (with `$1`
+  /// tab stops and `\$` for literal dollars).
   pub text: String,
   pub action: CompletionAction,
+  pub kind: CompletionKind,
 }
 
 #[derive(Debug)]
 enum AllowedCompletionType<'text> {
   None,
+  /// A variable reference is allowed here. `None` means there is no existing
+  /// variable token, so a name is inserted at the cursor. `Some((span, name))`
+  /// means a (possibly partial) variable `name` already occupies `span`, which
+  /// is replaced by the chosen name.
   Variable(Option<(Span, &'text str)>),
+  /// A declaration or matcher is allowed here (root of a complex or empty
+  /// message). `allow_match` is false when the message already has a body (a
+  /// matcher or a quoted pattern), since there can only be one. `replace` is the
+  /// span of a partially-typed declaration keyword at the cursor (e.g. `.` or
+  /// `.lo`) that the snippet should replace, if any.
+  Declaration {
+    allow_match: bool,
+    replace: Option<Span>,
+  },
 }
 
 pub struct CompletionsProvider<'scope: 'text, 'text> {
@@ -36,10 +62,11 @@ impl<'scope, 'text> CompletionsProvider<'scope, 'text> {
     ast: &'ast Message<'text>,
     loc: Location,
     scope: &'scope Scope<'text>,
+    diagnostics: &[Diagnostic<'text>],
   ) -> Self {
     Self {
       scope,
-      completion_type: get_completion_type(ast, loc),
+      completion_type: get_completion_type(ast, loc, diagnostics),
     }
   }
 
@@ -50,12 +77,21 @@ impl<'scope, 'text> CompletionsProvider<'scope, 'text> {
   pub fn get_completions(&self) -> Vec<Completion> {
     match self.completion_type {
       AllowedCompletionType::None => vec![],
+      AllowedCompletionType::Declaration {
+        allow_match,
+        replace,
+      } => declaration_completions(allow_match, replace),
       AllowedCompletionType::Variable(None) => self
         .scope
         .get_names()
-        .map(|n| Completion {
-          text: format!("${}", n),
-          action: CompletionAction::Insert,
+        .map(|n| {
+          let text = format!("${}", n);
+          Completion {
+            label: text.clone(),
+            text,
+            action: CompletionAction::Insert,
+            kind: CompletionKind::Variable,
+          }
         })
         .collect(),
       AllowedCompletionType::Variable(Some((span, name))) => {
@@ -66,15 +102,51 @@ impl<'scope, 'text> CompletionsProvider<'scope, 'text> {
           .scope
           .get_names()
           .filter(|n| include_self || *n != name)
-          .map(|n| Completion {
-            text: format!("${}", n),
-            action: CompletionAction::Replace(span),
+          .map(|n| {
+            let text = format!("${}", n);
+            Completion {
+              label: text.clone(),
+              text,
+              action: CompletionAction::Replace(span),
+              kind: CompletionKind::Variable,
+            }
           });
 
         all_names.collect()
       }
     }
   }
+}
+
+fn declaration_completions(
+  allow_match: bool,
+  replace: Option<Span>,
+) -> Vec<Completion> {
+  let mut snippets = vec![
+    (".input", ".input {\\$${1:var} :${2:string}$0"),
+    (".local", ".local \\$${1:var} = {${2:value}}$0"),
+  ];
+  if allow_match {
+    snippets.push((
+      ".match",
+      ".match \\$${1:var}\n${2:key} {{${3:value}}}\n* {{${4:other}}}$0",
+    ));
+  }
+
+  snippets
+    .into_iter()
+    .map(|(label, text)| Completion {
+      label: label.to_string(),
+      text: text.to_string(),
+      action: match replace {
+        // Replace a partially-typed keyword (e.g. `.lo`) so we don't end up
+        // with `..local`.
+        Some(span) => CompletionAction::Replace(span),
+        None => CompletionAction::Insert,
+      },
+      kind: CompletionKind::Snippet,
+    })
+    .collect()
 }
 
 struct CompletionLocationVisitor<'ast, 'text> {
@@ -106,6 +178,7 @@ impl<'ast, 'text> VisitAny<'ast, 'text>
 fn get_completion_type<'text>(
   ast: &Message<'text>,
   loc: Location,
+  diagnostics: &[Diagnostic<'text>],
 ) -> AllowedCompletionType<'text> {
   let mut visitor = CompletionLocationVisitor {
     loc,
@@ -125,7 +198,56 @@ fn get_completion_type<'text>(
   use ast::*;
   use AnyNode as X;
 
+  let get_invalid_statement_span = || {
+    diagnostics.iter().find_map(|diagnostic| match diagnostic {
+      Diagnostic::InvalidStatement { span, .. }
+        if span.start < loc && loc <= span.end =>
+      {
+        Some(*span)
+      }
+      _ => None,
+    })
+  };
+
+  // An empty (or whitespace-only) message is parsed as a simple message with a
+  // single empty text part. Offer declaration snippets at its root.
+  if let Message::Simple(pattern) = ast {
+    if let [PatternPart::Text(text)] = &pattern.parts[..] {
+      if text.content.trim().is_empty() {
+        return AllowedCompletionType::Declaration {
+          allow_match: true,
+          replace: get_invalid_statement_span(),
+        };
+      }
+    }
+  }
+
+  let has_body = |message: &ComplexMessage| match &message.body {
+    ComplexMessageBody::Matcher(_) => true,
+    ComplexMessageBody::QuotedPattern(pattern) => !pattern.span().is_empty(),
+  };
+
+  // The cursor can be in whitespace just outside the complex message's span
+  // (e.g. on a fresh line after the last declaration). As long as there is no
+  // body yet, that is still a valid spot for another declaration.
+  if let (X::Message(_), Message::Complex(message)) = (&current_node, ast) {
+    if !has_body(message) {
+      return AllowedCompletionType::Declaration {
+        allow_match: true,
+        replace: get_invalid_statement_span(),
+      };
+    }
+  }
+
   match (current_node, parent_node, previous_node) {
+    (X::ComplexMessage(message), _, _) => {
+      // At the root of a complex message, in between declarations or before the
+      // body: `.local ...` <here> `{{...}}`.
+      AllowedCompletionType::Declaration {
+        replace: get_invalid_statement_span(),
+        allow_match: !has_body(message),
+      }
+    }
     (X::Variable(var), _, _) => {
       // $f|
       AllowedCompletionType::Variable(Some((var.span(), var.name)))
@@ -190,8 +312,8 @@ mod tests {
         $source.find('┋').expect("Cursor not found") as u32,
       );
       let message = $source.replace('┋', "");
-      let (ast, ..) = parse(&message);
-      let result = get_completion_type(&ast, loc);
+      let (ast, diagnostics, _) = parse(&message);
+      let result = get_completion_type(&ast, loc, &diagnostics);
 
       assert!(
         matches!(result, $expected),
@@ -232,5 +354,24 @@ mod tests {
     assert_completion_type!("{ $x :fn param=┋}", AllowedCompletionType::Variable(None));
     assert_completion_type!("{ ┋ :fn }", AllowedCompletionType::Variable(None));
     assert_completion_type!("{ $x┋ :fn }", AllowedCompletionType::Variable(Some((_, "x"))));
+
+    // Declaration snippets at the root of an empty or complex message. A
+    // partially-typed keyword is reported as a replace span.
+    assert_completion_type!("┋", AllowedCompletionType::Declaration { allow_match: true, replace: None });
+    assert_completion_type!("  ┋  ", AllowedCompletionType::Declaration { allow_match: true, replace: None });
+    assert_completion_type!(".┋", AllowedCompletionType::Declaration { allow_match: true, replace: Some(_) });
+    assert_completion_type!(".in┋", AllowedCompletionType::Declaration { allow_match: true, replace: Some(_) });
+    assert_completion_type!(".input {$x}\n┋", AllowedCompletionType::Declaration { allow_match: true, replace: None });
+    // A partial keyword after an earlier declaration is still replaced.
+    assert_completion_type!(".local $x = {1}\n.ma┋", AllowedCompletionType::Declaration { allow_match: true, replace: Some(_) });
+    // A body already exists, so `.match` is not offered.
+    assert_completion_type!(".local $x = {1}\n┋\n{{hi}}", AllowedCompletionType::Declaration { allow_match: false, replace: None });
+    assert_completion_type!(".local $x = {1}\n┋\n.match $x\n* {{a}}", AllowedCompletionType::Declaration { allow_match: false, replace: None });
+    // Inside a matcher variant's pattern, declarations are not offered.
+    assert_completion_type!(".match $x\n* {{┋}}", AllowedCompletionType::None);
+    // Not at the root of a simple message with content.
+    assert_completion_type!("┋Hello", AllowedCompletionType::None);
+    assert_completion_type!("Hello┋", AllowedCompletionType::None);
+    assert_completion_type!("{{┋}}", AllowedCompletionType::None);
   }
 }

--- a/lsp/src/server.rs
+++ b/lsp/src/server.rs
@@ -28,7 +28,9 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
 use crate::ast_utils::find_node;
+use crate::completions::Completion;
 use crate::completions::CompletionAction;
+use crate::completions::CompletionKind;
 use crate::completions::CompletionsProvider;
 use crate::document::Document;
 use crate::protocol::LanguageClient;
@@ -128,7 +130,7 @@ impl LanguageServer for Server<'_> {
         all_commit_characters: None,
         completion_item: None,
         resolve_provider: Some(false),
-        trigger_characters: Some(vec!["$".to_string()]),
+        trigger_characters: Some(vec!["$".to_string(), ".".to_string()]),
         work_done_progress_options: lsp_types::WorkDoneProgressOptions::default(
         ),
       }),
@@ -362,6 +364,7 @@ impl LanguageServer for Server<'_> {
       document.ast(),
       document.pos_to_loc(position),
       document.scope(),
+      document.diagnostics(),
     );
 
     if !provider.has_completions() {
@@ -372,24 +375,7 @@ impl LanguageServer for Server<'_> {
       provider
         .get_completions()
         .into_iter()
-        .map(|completion| match completion.action {
-          CompletionAction::Insert => lsp_types::CompletionItem {
-            label: completion.text,
-            kind: Some(lsp_types::CompletionItemKind::VARIABLE),
-            ..lsp_types::CompletionItem::default()
-          },
-          CompletionAction::Replace(span) => lsp_types::CompletionItem {
-            label: completion.text.clone(),
-            kind: Some(lsp_types::CompletionItemKind::VARIABLE),
-            text_edit: Some(lsp_types::CompletionTextEdit::Edit(
-              lsp_types::TextEdit {
-                range: document.span_to_range(span),
-                new_text: completion.text,
-              },
-            )),
-            ..lsp_types::CompletionItem::default()
-          },
-        })
+        .map(|completion| completion_to_lsp(completion, document))
         .collect(),
     )))
   }
@@ -467,6 +453,43 @@ impl LanguageServer for Server<'_> {
       range: document.span_to_range(document.ast().span()),
       new_text: formatted,
     }]))
+  }
+}
+
+fn completion_to_lsp(
+  completion: Completion,
+  document: &Document,
+) -> lsp_types::CompletionItem {
+  let (kind, insert_text_format) = match completion.kind {
+    CompletionKind::Variable => (lsp_types::CompletionItemKind::VARIABLE, None),
+    CompletionKind::Snippet => (
+      lsp_types::CompletionItemKind::SNIPPET,
+      Some(lsp_types::InsertTextFormat::SNIPPET),
+    ),
+  };
+
+  let (insert_text, text_edit) = match completion.action {
+    CompletionAction::Insert => {
+      let insert_text =
+        (completion.text != completion.label).then_some(completion.text);
+      (insert_text, None)
+    }
+    CompletionAction::Replace(span) => (
+      None,
+      Some(lsp_types::CompletionTextEdit::Edit(lsp_types::TextEdit {
+        range: document.span_to_range(span),
+        new_text: completion.text,
+      })),
+    ),
+  };
+
+  lsp_types::CompletionItem {
+    label: completion.label,
+    kind: Some(kind),
+    insert_text_format,
+    insert_text,
+    text_edit,
+    ..lsp_types::CompletionItem::default()
   }
 }
 

--- a/lsp/test/main_test.ts
+++ b/lsp/test/main_test.ts
@@ -532,15 +532,19 @@ Deno.test("declaration completions", async (t) => {
     insertText: SNIPPETS[label],
     insertTextFormat: 2,
   });
-  const replaced = (label: Keyword, end: number): CompletionItem => ({
+  const replaced = (
+    label: Keyword,
+    end: number,
+    line = 0,
+  ): CompletionItem => ({
     kind: 15,
     label,
     insertTextFormat: 2,
     textEdit: {
       newText: SNIPPETS[label],
       range: {
-        start: { line: 0, character: 0 },
-        end: { line: 0, character: end },
+        start: { line, character: 0 },
+        end: { line, character: end },
       },
     },
   });
@@ -589,6 +593,12 @@ Deno.test("declaration completions", async (t) => {
       replaced(".local", 2),
       replaced(".match", 2),
     ]);
+
+    assertEquals(await completionsFor(".loc", 0, 2), [
+      replaced(".input", 4),
+      replaced(".local", 4),
+      replaced(".match", 4),
+    ]);
   });
 
   await t.step("omits .match once a body exists", async () => {
@@ -597,6 +607,28 @@ Deno.test("declaration completions", async (t) => {
       inserted(".local"),
     ]);
   });
+
+  await t.step(
+    "replaces a keyword between declarations without eating the newline",
+    async () => {
+      // The cursor is inside `.loc`, which sits between a declaration and a
+      // `.match` body. The replacement must cover only `.loc` (not the
+      // following newline), and `.match` is omitted since a body already exists.
+      // The unrelated error on the first line (`= 1` is missing braces) must not
+      // be mistaken for the keyword being replaced.
+      assertEquals(
+        await completionsFor(
+          ".local $foo = 1\n.loc\n.match $foo\n* {{}}",
+          1,
+          3,
+        ),
+        [
+          replaced(".input", 4, 1),
+          replaced(".local", 4, 1),
+        ],
+      );
+    },
+  );
 
   await t.step("not inside a pattern", async () => {
     assertEquals(await completionsFor("{{hi}}", 0, 3), null);

--- a/lsp/test/main_test.ts
+++ b/lsp/test/main_test.ts
@@ -514,6 +514,95 @@ Deno.test("completions", async (t) => {
   });
 });
 
+Deno.test("declaration completions", async (t) => {
+  await using lsp = new AutoLSPTest();
+
+  await lsp.initialize();
+
+  const SNIPPETS = {
+    ".input": ".input {\\$${1:var} :${2:string}$0",
+    ".local": ".local \\$${1:var} = {${2:value}}$0",
+    ".match": ".match \\$${1:var}\n${2:key} {{${3:value}}}\n* {{${4:other}}}$0",
+  };
+  type Keyword = keyof typeof SNIPPETS;
+
+  const inserted = (label: Keyword): CompletionItem => ({
+    kind: 15,
+    label,
+    insertText: SNIPPETS[label],
+    insertTextFormat: 2,
+  });
+  const replaced = (label: Keyword, end: number): CompletionItem => ({
+    kind: 15,
+    label,
+    insertTextFormat: 2,
+    textEdit: {
+      newText: SNIPPETS[label],
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: end },
+      },
+    },
+  });
+
+  function sort(response: CompletionList | CompletionItem[] | null) {
+    if (Array.isArray(response)) {
+      response.sort((a: { label: string }, b: { label: string }) =>
+        a.label.localeCompare(b.label)
+      );
+    }
+  }
+
+  let version = 0;
+  async function completionsFor(text: string, line: number, character: number) {
+    const uri = `file:///src/decl${version}.mf2`;
+    await lsp.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "mf2", version: ++version, text },
+    });
+    const response = await lsp.request("textDocument/completion", {
+      textDocument: { uri },
+      position: { line, character },
+    });
+    sort(response);
+    return response;
+  }
+
+  await t.step("in an empty document", async () => {
+    assertEquals(await completionsFor("", 0, 0), [
+      inserted(".input"),
+      inserted(".local"),
+      inserted(".match"),
+    ]);
+  });
+
+  await t.step("at the root of a complex message", async () => {
+    assertEquals(await completionsFor(".local $x = {1}\n\n", 2, 0), [
+      inserted(".input"),
+      inserted(".local"),
+      inserted(".match"),
+    ]);
+  });
+
+  await t.step("replaces a partially-typed keyword", async () => {
+    assertEquals(await completionsFor(".l", 0, 2), [
+      replaced(".input", 2),
+      replaced(".local", 2),
+      replaced(".match", 2),
+    ]);
+  });
+
+  await t.step("omits .match once a body exists", async () => {
+    assertEquals(await completionsFor(".input {$x}\n\n{{hi}}", 1, 0), [
+      inserted(".input"),
+      inserted(".local"),
+    ]);
+  });
+
+  await t.step("not inside a pattern", async () => {
+    assertEquals(await completionsFor("{{hi}}", 0, 3), null);
+  });
+});
+
 Deno.test("formatting", async (t) => {
   await using lsp = new AutoLSPTest();
 


### PR DESCRIPTION
Offer `.input`, `.local`, and `.match` snippet completions when the
cursor is at the root of a complex or empty message. `.match` is only
suggested when the message has no body yet. A partially-typed keyword
(e.g. `.` or `.lo`) is replaced using the span from the parser's
invalid-statement diagnostic.
