### PR TITLE
Fix formatter appending a newline on every run

### DIFF
--- a/lsp/src/server.rs
+++ b/lsp/src/server.rs
@@ -464,7 +464,7 @@ impl LanguageServer for Server<'_> {
     let formatted = mf2_printer::print(document.ast(), Some(document.info()));
 
     Ok(Some(vec![lsp_types::TextEdit {
-      range: document.span_to_range(document.ast().span()),
+      range: document.span_to_range(document.info().span()),
       new_text: formatted,
     }]))
   }

--- a/lsp/test/main_test.ts
+++ b/lsp/test/main_test.ts
@@ -551,6 +551,31 @@ Deno.test("formatting", async (t) => {
     ]);
   });
 
+  await t.step("is idempotent for already-formatted code", async () => {
+    const uri = "file:///src/test-1b.mf2";
+
+    const text = ".input {$var :string}\n{{ asd {$var} }}\n";
+
+    await lsp.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "mf2", version: 1, text },
+    });
+
+    const res = await lsp.request("textDocument/formatting", {
+      textDocument: { uri },
+      options: { tabSize: 2, insertSpaces: true },
+    });
+
+    assertEquals(res, [
+      {
+        newText: text,
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 2, character: 0 },
+        },
+      },
+    ]);
+  });
+
   await t.step("formats code with scope errors", async () => {
     const uri = "file:///src/test-2.mf2";
 


### PR DESCRIPTION
Document formatting replaced only the AST span, which ends before the
trailing newline the printer emits. Each format left the existing
trailing newline in place and added another, so formatting was not
idempotent. Replace the whole document range instead.

Fixes #122
